### PR TITLE
Remove 'ben' as a prefix since it is a common first name

### DIFF
--- a/full-name-splitter.gemspec
+++ b/full-name-splitter.gemspec
@@ -36,8 +36,7 @@ Gem::Specification.new do |s|
   s.summary = %q{FullNameSplitter splits full name into first and last name considering name prefixes and initials}
   s.test_files = [
     "spec/lib/full-name-splitter_spec.rb",
-     "spec/spec_helper.rb",
-     "examples/generate_usernames.rb"
+    "spec/spec_helper.rb"
   ]
 
   if s.respond_to? :specification_version then

--- a/lib/full-name-splitter.rb
+++ b/lib/full-name-splitter.rb
@@ -2,7 +2,7 @@
 # requires full accessable first_name and last_name attributes
 module FullNameSplitter
 
-  PREFIXES = %w(de da la du del dei vda. dello della degli delle van von der den heer ten ter vande vanden vander voor ver aan mc ben).freeze
+  PREFIXES = %w(de da la du del dei vda. dello della degli delle van von der den heer ten ter vande vanden vander voor ver aan mc).freeze
 
   class Splitter
     


### PR DESCRIPTION
We're having issues where if someone's first name is Ben, full name splitter thinks its a prefix for a last name. For instance, splitting "Ben Franklin" returns [nil, "Ben Franklin"].
