### PR TITLE
reverse names that are split by comma

### DIFF
--- a/lib/full-name-splitter.rb
+++ b/lib/full-name-splitter.rb
@@ -93,8 +93,8 @@ module FullNameSplitter
     
     if name.include?(',')
       name.
-        split(/\s*,\s*/, 2).            # ",van  helsing" produces  ["", "van helsing"]
-        map{ |u| u.empty? ? nil : u }   # but it should be [nil, "van helsing"] by lib convection
+        split(/\s*,\s*/, 2).reverse.    # ",George" produces  ["George", ""]
+        map{ |u| u.empty? ? nil : u }   # but it should be ["George", nil] by lib convection
     else
       splitter = Splitter.new(name)
       [splitter.first_name, splitter.last_name]

--- a/spec/lib/full-name-splitter_spec.rb
+++ b/spec/lib/full-name-splitter_spec.rb
@@ -96,6 +96,10 @@ describe Incognito do
       " van  helsing , "                  => [nil, "van helsing"                  ],
       "\t van  der Rohe , Ludwig  Mies \t" => ["Ludwig Mies", "van der Rohe"       ],
 
+      # Test all caps
+      "JOHN SMITH"                    => ["John",           "Smith"              ],
+      "JOHN QUINCY ADAMS"             => ["John Quincy",    "Adams"              ],
+      "LUDWIG MIES VAN DER ROHE"      => ["Ludwig", "Mies Van Der Rohe"          ]
     }.
 
     each do |full_name, split_name|

--- a/spec/lib/full-name-splitter_spec.rb
+++ b/spec/lib/full-name-splitter_spec.rb
@@ -31,7 +31,6 @@ describe Incognito do
       "Gabriel Van Helsing"           => ["Gabriel",        "Van Helsing"         ],
       "Pierre de Montesquiou"         => ["Pierre",         "de Montesquiou"      ],
       "Charles d'Artagnan"            => ["Charles",        "d'Artagnan"          ],
-      "Jaazaniah ben Shaphan"         => ["Jaazaniah",      "ben Shaphan"         ],
       "Noda' bi-Yehudah"              => ["Noda'",          "bi-Yehudah"          ],
       "Maria del Carmen Menendez"     => ["Maria",          "del Carmen Menendez" ],
       "Alessandro Del Piero"          => ["Alessandro",     "Del Piero"           ],
@@ -84,18 +83,18 @@ describe Incognito do
       # the architect Ludwig Mies van der Rohe, from the West German city of Aachen, was originally Ludwig Mies;
       "Ludwig Mies van der Rohe"      => ["Ludwig",         "Mies van der Rohe"   ],
 
-      # If comma is provided then split by comma
+      # If comma is provided then split by comma and reverse
 
-      "John, Quincy Adams"             => ["John",    "Quincy Adams"              ],
-      "Ludwig Mies, van der Rohe"      => ["Ludwig Mies", "van der Rohe"          ],
+      "Quincy Adams, John"             => ["John",    "Quincy Adams"              ],
+      "van der Rohe, Ludwig Mies"      => ["Ludwig Mies", "van der Rohe"          ],
 
       # Test ignoring unnecessary whitespaces
       "\t Ludwig  Mies\t van der Rohe "   => ["Ludwig", "Mies van der Rohe"       ],
-      "\t Ludwig  Mies,\t van  der Rohe " => ["Ludwig Mies", "van der Rohe"       ],
+      "\t van  der Rohe ,\t Ludwig  Mies" => ["Ludwig Mies", "van der Rohe"       ],
       "\t Ludwig      "                   => ["Ludwig", nil                       ],
       "  van  helsing "                   => [nil, "van helsing"                  ],
-      " , van  helsing "                  => [nil, "van helsing"                  ],
-      "\t Ludwig  Mies,\t van  der Rohe " => ["Ludwig Mies", "van der Rohe"       ],
+      " van  helsing , "                  => [nil, "van helsing"                  ],
+      "\t van  der Rohe , Ludwig  Mies \t" => ["Ludwig Mies", "van der Rohe"       ],
 
     }.
 


### PR DESCRIPTION
Commonly a comma is used in reversed names (Last, First). If this is not what you expect feel free to reject this PR and I'll keep it on my fork.